### PR TITLE
Fix autoload error

### DIFF
--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -10,7 +10,7 @@ $integrationTestDir = __DIR__.'/../../integration';
 $fixtureBaseDir = $integrationTestDir.'/testsuite';
 
 require_once __DIR__ . '/../../../../app/bootstrap.php';
-require_once 'autoload.php';
+require_once __DIR__ . '/autoload.php';
 
 
 if (!defined('TESTS_TEMP_DIR')) {


### PR DESCRIPTION
`autoload.php` was not being included, so I prefixed it with `__DIR__` to solve it.

I encountered it on Magento 2.2.7 with PHP 7.1