### PR TITLE
Allow for file dev/tests/quick-integration/etc/config.php

### DIFF
--- a/framework/ReachDigital/TestFramework/Application.php
+++ b/framework/ReachDigital/TestFramework/Application.php
@@ -23,7 +23,11 @@ class Application extends \Magento\TestFramework\Application
         $this->_ensureDirExists($this->_configDir);
 
         $file = $this->_globalConfigDir . '/config.php';
-        $targetFile = $this->_configDir . str_replace($this->_globalConfigDir, '', $file);
+        if (file_exists(TESTS_ROOT_DIR . '/etc/config.php')) {
+            $file = TESTS_ROOT_DIR . '/etc/config.php';
+        }
+
+        $targetFile = $this->installDir . '/etc/config.php';
 
         $this->_ensureDirExists(dirname($targetFile));
         if ($file !== $targetFile) {

--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -12,6 +12,9 @@ $fixtureBaseDir = $integrationTestDir.'/testsuite';
 require_once __DIR__ . '/../../../../app/bootstrap.php';
 require_once __DIR__ . '/autoload.php';
 
+if (!defined('TESTS_ROOT_DIR')) {
+    define('TESTS_ROOT_DIR', dirname(__DIR__));
+}
 
 if (!defined('TESTS_TEMP_DIR')) {
     define('TESTS_TEMP_DIR', $integrationTestDir . '/tmp');


### PR DESCRIPTION
This PR adds the option to copy your own `config.php` which is taken so far from your global `app/etc/config.php` file, from the directory `dev/tests/quick-integration/etc/` as well.

The main reason for me to want this, is that in my Integration Tests I was using some core fixtures that required an immense rollback (deleting all products, categories, customers, orders), if the sample data modules were enabled. On a global level (my dev environment) I want the sample data to be there. But on an integration testing level, those sample data make little sense. Copying over the `config.php` from `app/etc/` into `dev/tests/quick-integration/etc/` allows any developer to customize the differences.