### PR TITLE
Make compatible with PHPUnit 9.5.x

### DIFF
--- a/framework/ReachDigital/TestFramework/Annotation/AppIsolation.php
+++ b/framework/ReachDigital/TestFramework/Annotation/AppIsolation.php
@@ -6,6 +6,7 @@
 namespace ReachDigital\TestFramework\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Test as TestUtil;
 
 /**
  * Rewrite of \Magento\TestFramework\Annotation\AppIsolation because that class will always reinitialize on each test
@@ -74,7 +75,7 @@ class AppIsolation
     private function isTestMagentoAppIsolationEnabled(TestCase $testCase)
     {
         /* Determine an isolation from doc comment */
-        $annotations = $testCase->getAnnotations();
+        $annotations = TestUtil::parseTestMethodAnnotations(get_class($testCase), $testCase->getName(false));
         $annotations = array_replace((array) $annotations['class'], (array) $annotations['method']);
 
         if (isset($annotations['magentoAppIsolation'])) {


### PR DESCRIPTION
Magento 2.4.4 uses PHPUnit 9.5.x.  
Earlier versions of PHPUnit can not be used because of the dependency on PHP 8.1.

This change is backward compatible (checked until PHPUnit 6.0), so no special case is needed to distinguish between older and newer PHPUnit versions.