### PR TITLE
Update bootstrap setCustomErrorHandler

### DIFF
--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -177,7 +177,8 @@ function rdTimerStart($name, $asFloat = false): callable
 function setCustomErrorHandler()
 {
     set_error_handler(function ($errNo, $errStr, $errFile, $errLine) {
-        if (error_reporting()) {
+        $errLevel = error_reporting();
+        if (($errLevel & $errNo) !== 0) {
             $errorNames = [
                 E_ERROR => 'Error',
                 E_WARNING => 'Warning',


### PR DESCRIPTION
Magento 2.4.4-p1 made a change to setCustomErrorHandler. 
Any fixtures which trigger the indexer, e.g. product creation, cause an Elasticsearch error "Specifying types in urls has been deprecated" which is not handled in the same way as as core integration tests and causes the test to fail.

Magento Changes: https://github.com/magento/magento2/commit/2b9b6d81caaedf21f747c28187fe8244b08fa8ef 
Github Issue: https://github.com/ho-nl/magento2-ReachDigital_TestFramework/issues/30